### PR TITLE
app.pagerduty.com -> identity.pagerduty.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ If all goes well, the callback page on the sample should present a friendly welc
 ## The Code
 Authorizing through OAuth involves making a request to PagerDuty for an authorization code. That request includes the Client ID that was generated when registering your app as well as the Redirect URI.
 
-To initiate the flow make a `GET` call to `https://app.pagerduty.com/oauth/authorize` with the query string parameters listed in `authParams` as seen below.
+To initiate the flow make a `GET` call to `https://identity.pagerduty.com/oauth/authorize` with the query string parameters listed in `authParams` as seen below.
 
 ```javascript
-const baseOAuthUrl = "https://app.pagerduty.com/oauth";
+const baseOAuthUrl = "https://identity.pagerduty.com/oauth";
 
 const authParams = {
     response_type: 'code',
@@ -50,9 +50,9 @@ const authUrl = `${baseOAuthUrl}/authorize?${qs.stringify(authParams)}`;
 ```
 The values for `client_id` and `redirect_uri` are taken from `config.json`, and `response_type` is important as it tells PagerDuty what type of flow is being initiated. In this case, by setting `response_type: 'code'` the flow is an Authorization Grant Flow. The `state` parameter is entirely optional. This is used when information about the state of app is needed at the end of the OAuth flow. For more information on the `state` parameter see the [Authorization Code Grant](https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/) article on [oauth.com](https://oauth.com).
 
-A successful response from calling the `https://app.pagerduty.com/oauth/authorize` endpoint should result in PagerDuty calling the `redirect_uri` you specified, which is the `/callback` in this project. The function at `/callback` is expecting PagerDuty to send a `code` in the query string. Using this `code` and the `PD_CLIENT_SECRET` in `config.json` you are now ready to request an access token. The callback will also return the `state` parameter, if that was sent with the `authParams`.
+A successful response from calling the `https://identity.pagerduty.com/oauth/authorize` endpoint should result in PagerDuty calling the `redirect_uri` you specified, which is the `/callback` in this project. The function at `/callback` is expecting PagerDuty to send a `code` in the query string. Using this `code` and the `PD_CLIENT_SECRET` in `config.json` you are now ready to request an access token. The callback will also return the `state` parameter, if that was sent with the `authParams`.
 
-To request an access token from PagerDuty you'll `POST` the values from `tokenParams` shown below in the body of the request to `https://app.pagerduty.com/oauth/token`. 
+To request an access token from PagerDuty you'll `POST` the values from `tokenParams` shown below in the body of the request to `https://identity.pagerduty.com/oauth/token`. 
 
 ```javascript
 const tokenParams = {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const port = process.env.PORT || 5000;
 const stateParm = "yourState";
 
 // baseOAuthUrl -- endpoint for initiating an OAuth flow
-const baseOAuthUrl = "https://app.pagerduty.com/oauth";
+const baseOAuthUrl = "https://identity.pagerduty.com/oauth";
 
 // parameters to send to the `oauth/authorize` endpoint to initiate flow
 const authParams = {


### PR DESCRIPTION
Eventually we are going to deprecate OAuth routes at app.pagerduty.com. Let's update our sample apps to get new apps on the correct path